### PR TITLE
Initialize microservice infra sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
 # high-perf-secure-cloud-arch
+
+This repository accompanies the article **"Architectural Solutions for High-Performance Secure Cloud Applications"**. It demonstrates a simple microservices stack with infrastructure-as-code and load testing tools.
+
+## Requirements
+- Docker >= 24
+- Terraform >= 1.7
+- AWS CLI v2 configured with a free-tier account
+
+## Quick Start
+
+### Build and Start Services
+```bash
+# build-up
+docker-compose up -d
+```
+
+### Run Load Tests
+```bash
+# run-tests
+jmeter -n -t jmeter/microservices-test-plan.jmx -Jjwt=<your_jwt>
+```
+
+### Tear Down Infrastructure
+```bash
+# teardown
+terraform -chdir=terraform destroy
+```
+
+## Terraform Usage
+```bash
+terraform -chdir=terraform init
+terraform -chdir=terraform apply
+```
+The provided configuration deploys a small ECS cluster behind an Application Load Balancer. Autoscaling keeps 1–3 tasks running based on CPU load.
+
+## JMeter Example
+Use the following command line when running tests:
+```bash
+jmeter -n -t jmeter/microservices-test-plan.jmx \
+    -Jjwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+## Logs
+Sample run data lives in `logs/sample_run.csv` for reference.
+
+## License
+Content is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3.9'  # Compose specification
+
+services:
+  account-svc:
+    image: node:18-alpine
+    command: node account.js  # placeholder command
+    healthcheck:
+      test: ["CMD", "sh", "-c", "curl -f http://localhost:3000/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - internal_net
+
+  content-svc:
+    image: node:18-alpine
+    command: node content.js
+    healthcheck:
+      test: ["CMD", "sh", "-c", "curl -f http://localhost:3000/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - internal_net
+
+  analytics-svc:
+    image: node:18-alpine
+    command: node analytics.js
+    healthcheck:
+      test: ["CMD", "sh", "-c", "curl -f http://localhost:3000/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - internal_net
+
+  redis:
+    image: redis:7-alpine
+    networks:
+      - internal_net
+
+networks:
+  internal_net:
+    driver: bridge

--- a/jmeter/microservices-test-plan.jmx
+++ b/jmeter/microservices-test-plan.jmx
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.4.3">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Microservices Test Plan" enabled="true">
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="jwt" elementType="Argument">
+            <stringProp name="Argument.name">jwt</stringProp>
+            <stringProp name="Argument.value"></stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </elementProp>
+    </TestPlan>
+    <hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Users" enabled="true">
+        <stringProp name="ThreadGroup.num_threads">100</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">10</stringProp>
+        </elementProp>
+      </ThreadGroup>
+      <hashTree>
+        <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="JWT Header" enabled="true">
+          <collectionProp name="HeaderManager.headers">
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">Authorization</stringProp>
+              <stringProp name="Header.value">Bearer ${jwt}</stringProp>
+            </elementProp>
+          </collectionProp>
+        </HeaderManager>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="GET profile" enabled="true">
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">3000</stringProp>
+          <stringProp name="HTTPSampler.protocol">http</stringProp>
+          <stringProp name="HTTPSampler.path">/api/profile</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="POST content" enabled="true">
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">3000</stringProp>
+          <stringProp name="HTTPSampler.protocol">http</stringProp>
+          <stringProp name="HTTPSampler.path">/api/content</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="GET analytics" enabled="true">
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">3000</stringProp>
+          <stringProp name="HTTPSampler.protocol">http</stringProp>
+          <stringProp name="HTTPSampler.path">/api/analytics</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/logs/sample_run.csv
+++ b/logs/sample_run.csv
@@ -1,0 +1,10 @@
+timestamp,url,rt_ms,http_code
+2024-01-01T00:00:01Z,/api/profile,123,200
+2024-01-01T00:00:02Z,/api/content,230,201
+2024-01-01T00:00:03Z,/api/analytics,150,200
+2024-01-01T00:00:04Z,/api/profile,110,200
+2024-01-01T00:00:05Z,/api/content,250,201
+2024-01-01T00:00:06Z,/api/analytics,180,200
+2024-01-01T00:00:07Z,/api/profile,135,200
+2024-01-01T00:00:08Z,/api/content,220,201
+2024-01-01T00:00:09Z,/api/analytics,175,200

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,202 @@
+terraform {
+  required_version = ">= 1.7"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+# ECS cluster using Fargate free tier
+resource "aws_ecs_cluster" "this" {
+  name = "hp-secure-cloud-cluster"
+}
+
+# IAM role for task execution
+resource "aws_iam_role" "task_exec" {
+  name = "ecsTaskExecutionRole"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task.json
+}
+
+data "aws_iam_policy_document" "ecs_task" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
+  role       = aws_iam_role.task_exec.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Task definition for account-svc
+resource "aws_ecs_task_definition" "account" {
+  family                   = "account-svc"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = aws_iam_role.task_exec.arn
+  task_role_arn            = aws_iam_role.task_exec.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "account-svc"
+      image     = "node:18-alpine"
+      essential = true
+      portMappings = [{
+        containerPort = 3000
+      }]
+      healthCheck = {
+        command     = ["CMD-SHELL", "curl -f http://localhost:3000/health || exit 1"]
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 10
+      }
+    }
+  ])
+}
+
+# TODO: add task definitions for content-svc and analytics-svc
+
+# Load balancer resources
+resource "aws_lb" "public" {
+  name               = "hp-secure-lb"
+  load_balancer_type = "application"
+  subnets            = data.aws_subnets.public.ids
+}
+
+resource "aws_lb_target_group" "tg" {
+  name     = "hp-tg"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = data.aws_vpc.main.id
+  health_check {
+    path                = "/health"
+    matcher             = "200"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.public.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.tg.arn
+  }
+}
+
+# Rule for /api/*
+resource "aws_lb_listener_rule" "api" {
+  listener_arn = aws_lb_listener.http.arn
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.tg.arn
+  }
+
+  condition {
+    path_pattern {
+      values = ["/api/*"]
+    }
+  }
+}
+
+# Security group
+resource "aws_security_group" "ecs" {
+  name   = "ecs-sg"
+  vpc_id = data.aws_vpc.main.id
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# ECS service for account-svc
+resource "aws_ecs_service" "account" {
+  name            = "account-svc"
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.account.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = data.aws_subnets.public.ids
+    security_groups = [aws_security_group.ecs.id]
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.tg.arn
+    container_name   = "account-svc"
+    container_port   = 3000
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+}
+
+# Autoscaling between 1 and 3 tasks when CPU > 70%
+resource "aws_appautoscaling_target" "ecs" {
+  max_capacity       = 3
+  min_capacity       = 1
+  resource_id        = "service/${aws_ecs_cluster.this.name}/${aws_ecs_service.account.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "cpu" {
+  name               = "cpu-scaling"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.ecs.resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.ecs.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    target_value       = 70
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 300
+  }
+}
+
+# Use default VPC and subnets
+data "aws_vpc" "main" {
+  default = true
+}
+
+data "aws_subnets" "public" {
+  filter {
+    name   = "default-for-az"
+    values = ["true"]
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,11 @@
+output "cluster_id" {
+  value = aws_ecs_cluster.this.id
+}
+
+output "service_name" {
+  value = aws_ecs_service.account.name
+}
+
+output "load_balancer_dns" {
+  value = aws_lb.public.dns_name
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,5 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}


### PR DESCRIPTION
## Summary
- add quickstart README
- define docker-compose stack for microservices with redis and healthchecks
- provide JMeter test plan for 100 users
- add Terraform configuration for ECS Fargate cluster
- include sample logs

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684eddb9508483259cd46b989479a30d