### PR TITLE
Add Express services with compose ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ jmeter -n -t jmeter/microservices-test-plan.jmx -Jjwt=<your_jwt>
 terraform -chdir=terraform destroy
 ```
 
+## Local ports
+
+| Service        | Port |
+|---------------|------|
+| account-svc   | 3001 |
+| content-svc   | 3002 |
+| analytics-svc | 3003 |
+
 ## Terraform Usage
 ```bash
 terraform -chdir=terraform init
@@ -35,7 +43,7 @@ terraform -chdir=terraform apply
 The provided configuration deploys a small ECS cluster behind an Application Load Balancer. Autoscaling keeps 1–3 tasks running based on CPU load.
 
 ## JMeter Example
-Use the following command line when running tests:
+Use the following command line when running tests. JMeter sends requests to `http://localhost:3001` by default:
 ```bash
 jmeter -n -t jmeter/microservices-test-plan.jmx \
     -Jjwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,11 @@ version: '3.9'  # Compose specification
 services:
   account-svc:
     image: node:18-alpine
-    command: node account.js  # placeholder command
+    command: node /app/server.js
+    volumes:
+      - ./src/account-svc/server.js:/app/server.js
+    ports:
+      - "3001:3000"
     healthcheck:
       test: ["CMD", "sh", "-c", "curl -f http://localhost:3000/health || exit 1"]
       interval: 30s
@@ -14,7 +18,11 @@ services:
 
   content-svc:
     image: node:18-alpine
-    command: node content.js
+    command: node /app/server.js
+    volumes:
+      - ./src/content-svc/server.js:/app/server.js
+    ports:
+      - "3002:3000"
     healthcheck:
       test: ["CMD", "sh", "-c", "curl -f http://localhost:3000/health || exit 1"]
       interval: 30s
@@ -25,7 +33,11 @@ services:
 
   analytics-svc:
     image: node:18-alpine
-    command: node analytics.js
+    command: node /app/server.js
+    volumes:
+      - ./src/analytics-svc/server.js:/app/server.js
+    ports:
+      - "3003:3000"
     healthcheck:
       test: ["CMD", "sh", "-c", "curl -f http://localhost:3000/health || exit 1"]
       interval: 30s

--- a/src/account-svc/server.js
+++ b/src/account-svc/server.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const app = express();
+app.use(express.json());
+app.get('/health', (req, res) => res.send('healthy'));
+app.get('/api/profile', (req, res) => res.json({user: 'demo'}));
+app.listen(3000, () => console.log('account-svc listening'));
+

--- a/src/analytics-svc/server.js
+++ b/src/analytics-svc/server.js
@@ -1,0 +1,6 @@
+const express = require('express');
+const app = express();
+app.get('/health', (req, res) => res.send('healthy'));
+app.get('/api/analytics', (req, res) => res.json({data: []}));
+app.listen(3000, () => console.log('analytics-svc listening'));
+

--- a/src/content-svc/server.js
+++ b/src/content-svc/server.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const app = express();
+app.use(express.json());
+app.get('/health', (req, res) => res.send('healthy'));
+app.post('/api/content', (req, res) => res.json({status: 'ok'}));
+app.listen(3000, () => console.log('content-svc listening'));
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -67,7 +67,63 @@ resource "aws_ecs_task_definition" "account" {
   ])
 }
 
-# TODO: add task definitions for content-svc and analytics-svc
+# Task definition for content-svc
+resource "aws_ecs_task_definition" "content" {
+  family                   = "content-svc"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = aws_iam_role.task_exec.arn
+  task_role_arn            = aws_iam_role.task_exec.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "content-svc"
+      image     = "node:18-alpine"
+      essential = true
+      portMappings = [{
+        containerPort = 3000
+      }]
+      healthCheck = {
+        command     = ["CMD-SHELL", "curl -f http://localhost:3000/health || exit 1"]
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 10
+      }
+    }
+  ])
+}
+
+# Task definition for analytics-svc
+resource "aws_ecs_task_definition" "analytics" {
+  family                   = "analytics-svc"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = aws_iam_role.task_exec.arn
+  task_role_arn            = aws_iam_role.task_exec.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "analytics-svc"
+      image     = "node:18-alpine"
+      essential = true
+      portMappings = [{
+        containerPort = 3000
+      }]
+      healthCheck = {
+        command     = ["CMD-SHELL", "curl -f http://localhost:3000/health || exit 1"]
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 10
+      }
+    }
+  ])
+}
 
 # Load balancer resources
 resource "aws_lb" "public" {
@@ -155,6 +211,54 @@ resource "aws_ecs_service" "account" {
   load_balancer {
     target_group_arn = aws_lb_target_group.tg.arn
     container_name   = "account-svc"
+    container_port   = 3000
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+}
+
+# ECS service for content-svc
+resource "aws_ecs_service" "content" {
+  name            = "content-svc"
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.content.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = data.aws_subnets.public.ids
+    security_groups = [aws_security_group.ecs.id]
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.tg.arn
+    container_name   = "content-svc"
+    container_port   = 3000
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+}
+
+# ECS service for analytics-svc
+resource "aws_ecs_service" "analytics" {
+  name            = "analytics-svc"
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.analytics.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = data.aws_subnets.public.ids
+    security_groups = [aws_security_group.ecs.id]
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.tg.arn
+    container_name   = "analytics-svc"
     container_port   = 3000
   }
 


### PR DESCRIPTION
## Summary
- add Express server stubs for account, content and analytics services
- publish ports and mount server scripts in docker-compose
- replicate ECS task/service definitions for new services
- document local ports and default JMeter target

## Testing
- `docker compose up -d` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ee04ab6cc8325adb27f78f151ea3b