### PR TITLE
feat: make repo fully runnable

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,12 @@
+name: lint
+on: push
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v2
+      - name: Terraform fmt
+        run: terraform -chdir=terraform fmt -check
+      - name: Docker Compose config
+        run: docker compose config -q

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ This repository accompanies the article **"Architectural Solutions for High-Perf
 docker-compose up -d
 ```
 
+### Build custom images
+```bash
+docker compose build
+```
+
 ### Run Load Tests
 ```bash
 # run-tests
@@ -43,7 +48,8 @@ terraform -chdir=terraform apply
 The provided configuration deploys a small ECS cluster behind an Application Load Balancer. Autoscaling keeps 1–3 tasks running based on CPU load.
 
 ## JMeter Example
-Use the following command line when running tests. JMeter sends requests to `http://localhost:3001` by default:
+Install JMeter via `brew install jmeter` or download it from the [official archive](https://jmeter.apache.org/download_jmeter.cgi).
+The test plan targets port 3001 by default. Override it with `-Jport=3002` if needed.
 ```bash
 jmeter -n -t jmeter/microservices-test-plan.jmx \
     -Jjwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,7 @@ version: '3.9'  # Compose specification
 
 services:
   account-svc:
-    image: node:18-alpine
-    command: node /app/server.js
+    build: ./src/account-svc
     volumes:
       - ./src/account-svc/server.js:/app/server.js
     ports:
@@ -17,8 +16,7 @@ services:
       - internal_net
 
   content-svc:
-    image: node:18-alpine
-    command: node /app/server.js
+    build: ./src/content-svc
     volumes:
       - ./src/content-svc/server.js:/app/server.js
     ports:
@@ -32,8 +30,7 @@ services:
       - internal_net
 
   analytics-svc:
-    image: node:18-alpine
-    command: node /app/server.js
+    build: ./src/analytics-svc
     volumes:
       - ./src/analytics-svc/server.js:/app/server.js
     ports:

--- a/jmeter/microservices-test-plan.jmx
+++ b/jmeter/microservices-test-plan.jmx
@@ -9,6 +9,11 @@
             <stringProp name="Argument.value"></stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="port" elementType="Argument">
+            <stringProp name="Argument.name">port</stringProp>
+            <stringProp name="Argument.value">3001</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </elementProp>
     </TestPlan>
@@ -33,7 +38,7 @@
         <hashTree/>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="GET profile" enabled="true">
           <stringProp name="HTTPSampler.domain">localhost</stringProp>
-          <stringProp name="HTTPSampler.port">3000</stringProp>
+          <stringProp name="HTTPSampler.port">${port}</stringProp>
           <stringProp name="HTTPSampler.protocol">http</stringProp>
           <stringProp name="HTTPSampler.path">/api/profile</stringProp>
           <stringProp name="HTTPSampler.method">GET</stringProp>
@@ -41,7 +46,7 @@
         <hashTree/>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="POST content" enabled="true">
           <stringProp name="HTTPSampler.domain">localhost</stringProp>
-          <stringProp name="HTTPSampler.port">3000</stringProp>
+          <stringProp name="HTTPSampler.port">${port}</stringProp>
           <stringProp name="HTTPSampler.protocol">http</stringProp>
           <stringProp name="HTTPSampler.path">/api/content</stringProp>
           <stringProp name="HTTPSampler.method">POST</stringProp>
@@ -59,7 +64,7 @@
         <hashTree/>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="GET analytics" enabled="true">
           <stringProp name="HTTPSampler.domain">localhost</stringProp>
-          <stringProp name="HTTPSampler.port">3000</stringProp>
+          <stringProp name="HTTPSampler.port">${port}</stringProp>
           <stringProp name="HTTPSampler.protocol">http</stringProp>
           <stringProp name="HTTPSampler.path">/api/analytics</stringProp>
           <stringProp name="HTTPSampler.method">GET</stringProp>

--- a/src/account-svc/Dockerfile
+++ b/src/account-svc/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY server.js .
+RUN npm install express
+CMD ["node","/app/server.js"]

--- a/src/analytics-svc/Dockerfile
+++ b/src/analytics-svc/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY server.js .
+RUN npm install express
+CMD ["node","/app/server.js"]

--- a/src/content-svc/Dockerfile
+++ b/src/content-svc/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY server.js .
+RUN npm install express
+CMD ["node","/app/server.js"]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -12,6 +12,10 @@ provider "aws" {
   region = var.region
 }
 
+locals {
+  container_image = "public.ecr.aws/docker/library/node:18-alpine"
+}
+
 # ECS cluster using Fargate free tier
 resource "aws_ecs_cluster" "this" {
   name = "hp-secure-cloud-cluster"
@@ -51,7 +55,7 @@ resource "aws_ecs_task_definition" "account" {
   container_definitions = jsonencode([
     {
       name      = "account-svc"
-      image     = "node:18-alpine"
+      image     = local.container_image
       essential = true
       portMappings = [{
         containerPort = 3000
@@ -80,7 +84,7 @@ resource "aws_ecs_task_definition" "content" {
   container_definitions = jsonencode([
     {
       name      = "content-svc"
-      image     = "node:18-alpine"
+      image     = local.container_image
       essential = true
       portMappings = [{
         containerPort = 3000
@@ -109,7 +113,7 @@ resource "aws_ecs_task_definition" "analytics" {
   container_definitions = jsonencode([
     {
       name      = "analytics-svc"
-      image     = "node:18-alpine"
+      image     = local.container_image
       essential = true
       portMappings = [{
         containerPort = 3000
@@ -282,6 +286,56 @@ resource "aws_appautoscaling_policy" "cpu" {
   resource_id        = aws_appautoscaling_target.ecs.resource_id
   scalable_dimension = aws_appautoscaling_target.ecs.scalable_dimension
   service_namespace  = aws_appautoscaling_target.ecs.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    target_value       = 70
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 300
+  }
+}
+
+resource "aws_appautoscaling_target" "content" {
+  max_capacity       = 3
+  min_capacity       = 1
+  resource_id        = "service/${aws_ecs_cluster.this.name}/${aws_ecs_service.content.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "content_cpu" {
+  name               = "content-cpu-scaling"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.content.resource_id
+  scalable_dimension = aws_appautoscaling_target.content.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.content.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    target_value       = 70
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 300
+  }
+}
+
+resource "aws_appautoscaling_target" "analytics" {
+  max_capacity       = 3
+  min_capacity       = 1
+  resource_id        = "service/${aws_ecs_cluster.this.name}/${aws_ecs_service.analytics.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "analytics_cpu" {
+  name               = "analytics-cpu-scaling"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.analytics.resource_id
+  scalable_dimension = aws_appautoscaling_target.analytics.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.analytics.service_namespace
 
   target_tracking_scaling_policy_configuration {
     target_value       = 70


### PR DESCRIPTION
## Summary
- build service containers from local Dockerfiles
- adjust compose for built images
- parameterize JMeter port usage
- document custom build and JMeter options
- add container image local to Terraform
- autoscale all services
- add lint workflow

## Testing
- `terraform -chdir=terraform fmt -check` *(fails: command not found)*
- `docker compose config -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee25058b083258c9d5f8c858d12ff