### PR TITLE
fix: clean duplicates & make repo runnable

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
       - uses: hashicorp/setup-terraform@v2
       - name: Terraform fmt
         run: terraform -chdir=terraform fmt -check

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository accompanies the article **"Architectural Solutions for High-Perf
 
 ### Build and Start Services
 ```bash
+docker compose build
 # build-up
 docker-compose up -d
 ```
@@ -49,7 +50,7 @@ The provided configuration deploys a small ECS cluster behind an Application Loa
 
 ## JMeter Example
 Install JMeter via `brew install jmeter` or download it from the [official archive](https://jmeter.apache.org/download_jmeter.cgi).
-The test plan targets port 3001 by default. Override it with `-Jport=3002` if needed.
+Перед запуском JMeter можно изменить порт: `-Jport=3002`.
 ```bash
 jmeter -n -t jmeter/microservices-test-plan.jmx \
     -Jjwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,7 @@ version: '3.9'  # Compose specification
 services:
   account-svc:
     build: ./src/account-svc
-    volumes:
-      - ./src/account-svc/server.js:/app/server.js
+    command: node /app/server.js
     ports:
       - "3001:3000"
     healthcheck:
@@ -17,8 +16,7 @@ services:
 
   content-svc:
     build: ./src/content-svc
-    volumes:
-      - ./src/content-svc/server.js:/app/server.js
+    command: node /app/server.js
     ports:
       - "3002:3000"
     healthcheck:
@@ -31,8 +29,7 @@ services:
 
   analytics-svc:
     build: ./src/analytics-svc
-    volumes:
-      - ./src/analytics-svc/server.js:/app/server.js
+    command: node /app/server.js
     ports:
       - "3003:3000"
     healthcheck:


### PR DESCRIPTION
## Summary
- clean up compose services and add command
- add build step to lint workflow
- clarify quick start and JMeter usage

## Testing
- `terraform fmt -check` *(fails: command not found)*
- `docker compose config -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee4601c4c832581701e802212bfd4