### PR TITLE
Enable request logging and remove JWT from load tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with: { python-version: '3.11' }
-      - run: pip install pandas --quiet
+      - name: Run JMeter
+        run: jmeter -n -t jmeter/microservices-test-plan.jmx -l logs/sample_run.csv
       - run: python3 scripts/aggregate_metrics.py
 
       # --- Trivy Scan ---

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ This repository accompanies the article **"Architectural Solutions for High-Perf
 - Terraform >= 1.7
 - AWS CLI v2 configured with a free-tier account
 - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` must be set for Terraform
-- `JWT` token used by JMeter load tests
 
 ## Quick Start
 
@@ -36,7 +35,7 @@ Run `python metrics.py` to aggregate metrics and generate a PDF report.
 ### Run Load Tests
 ```bash
 # run-tests
-jmeter -n -t jmeter/microservices-test-plan.jmx -Jjwt=<your_jwt>
+jmeter -n -t jmeter/microservices-test-plan.jmx
 ```
 
 ### Tear Down Infrastructure
@@ -60,8 +59,7 @@ The provided configuration deploys a small ECS cluster behind an Application Loa
 ## JMeter Example
 Install JMeter via `brew install jmeter` or download it from the [official archive](https://jmeter.apache.org/download_jmeter.cgi).
 ```bash
-jmeter -n -t jmeter/microservices-test-plan.jmx \
-    -Jjwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+jmeter -n -t jmeter/microservices-test-plan.jmx
 ```
 
 ## Logs

--- a/jmeter/microservices-test-plan.jmx
+++ b/jmeter/microservices-test-plan.jmx
@@ -27,6 +27,7 @@
         </elementProp>
       </ThreadGroup>
       <hashTree>
+        <!--
         <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="JWT Header" enabled="true">
           <collectionProp name="HeaderManager.headers">
             <elementProp name="" elementType="Header">
@@ -36,6 +37,7 @@
           </collectionProp>
         </HeaderManager>
         <hashTree/>
+        -->
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="GET profile" enabled="true">
           <stringProp name="HTTPSampler.domain">localhost</stringProp>
           <stringProp name="HTTPSampler.port">${port}</stringProp>

--- a/scripts/aggregate_metrics.py
+++ b/scripts/aggregate_metrics.py
@@ -1,21 +1,13 @@
 try:
     import pandas as pd
 except ModuleNotFoundError:
-    import subprocess
-    import sys
-    print("pandas not found, installing...")
+    import subprocess, sys
     subprocess.check_call([sys.executable, "-m", "pip", "install", "pandas"])
     import pandas as pd
 
 import argparse
-from pathlib import Path
 
 def _load_metrics(path: str) -> tuple[float, float]:
-    p = Path(path)
-    if not p.exists():
-        print(f"File {path} not found")
-        return 0.0, 0.0
-
     df = pd.read_csv(path, parse_dates=["timestamp"])
     if df.empty:
         return 0.0, 0.0
@@ -32,21 +24,24 @@ def main() -> None:
     parser.add_argument("--secure", help="CSV with secure metrics")
     args = parser.parse_args()
 
-    if args.baseline and args.secure:
-        baseline_tp, baseline_p95 = _load_metrics(args.baseline)
-        secure_tp, secure_p95 = _load_metrics(args.secure)
+    try:
+        if args.baseline and args.secure:
+            baseline_tp, baseline_p95 = _load_metrics(args.baseline)
+            secure_tp, secure_p95 = _load_metrics(args.secure)
 
-        tp_gain = ((secure_tp - baseline_tp) / baseline_tp * 100) if baseline_tp else 0.0
-        latency_change = ((secure_p95 - baseline_p95) / baseline_p95 * 100) if baseline_p95 else 0.0
+            tp_gain = ((secure_tp - baseline_tp) / baseline_tp * 100) if baseline_tp else 0.0
+            latency_change = ((secure_p95 - baseline_p95) / baseline_p95 * 100) if baseline_p95 else 0.0
 
-        print(f"Throughput: {secure_tp:.1f} req/s")
-        print(f"95th-percentile latency: {secure_p95:.0f} ms")
-        print(f"Gain: {tp_gain:+.1f}% throughput, {latency_change:+.1f}% latency")
-    else:
-        file_path = args.baseline or args.secure or "logs/sample_run.csv"
-        tp, p95 = _load_metrics(file_path)
-        print(f"Throughput: {tp:.1f} req/s")
-        print(f"95th-percentile latency: {p95:.0f} ms")
+            print(f"Throughput: {secure_tp:.1f} req/s")
+            print(f"95th-percentile latency: {secure_p95:.0f} ms")
+            print(f"Gain: {tp_gain:+.1f}% throughput, {latency_change:+.1f}% latency")
+        else:
+            file_path = args.baseline or args.secure or "logs/sample_run.csv"
+            tp, p95 = _load_metrics(file_path)
+            print(f"Throughput: {tp:.1f} req/s")
+            print(f"95th-percentile latency: {p95:.0f} ms")
+    except FileNotFoundError:
+        print("logs not found, skipping aggregation")
 
 if __name__ == '__main__':
     main()

--- a/src/account-svc/server.js
+++ b/src/account-svc/server.js
@@ -1,5 +1,19 @@
 const express = require('express');
+const fs = require('fs');
+const path = require('path');
 const app = express();
+
+app.use((req, res, next) => {
+  const start = process.hrtime.bigint();
+  res.on('finish', () => {
+    const end = process.hrtime.bigint();
+    const ms = Number(end - start) / 1e6;
+    const line = `${new Date().toISOString()},${req.originalUrl},${ms.toFixed(0)},${res.statusCode}\n`;
+    fs.appendFileSync(path.join(__dirname, '../../logs/sample_run.csv'), line);
+  });
+  next();
+});
+
 app.use(express.json());
 app.get('/health', (req, res) => res.send('healthy'));
 app.get('/api/profile', (req, res) => res.json({ user: 'demo' }));

--- a/src/analytics-svc/server.js
+++ b/src/analytics-svc/server.js
@@ -1,5 +1,19 @@
 const express = require('express');
+const fs = require('fs');
+const path = require('path');
 const app = express();
+
+app.use((req, res, next) => {
+  const start = process.hrtime.bigint();
+  res.on('finish', () => {
+    const end = process.hrtime.bigint();
+    const ms = Number(end - start) / 1e6;
+    const line = `${new Date().toISOString()},${req.originalUrl},${ms.toFixed(0)},${res.statusCode}\n`;
+    fs.appendFileSync(path.join(__dirname, '../../logs/sample_run.csv'), line);
+  });
+  next();
+});
+
 app.get('/health', (req, res) => res.send('healthy'));
 app.get('/api/analytics', (req, res) => res.json({ data: [] }));
 

--- a/src/content-svc/server.js
+++ b/src/content-svc/server.js
@@ -1,5 +1,19 @@
 const express = require('express');
+const fs = require('fs');
+const path = require('path');
 const app = express();
+
+app.use((req, res, next) => {
+  const start = process.hrtime.bigint();
+  res.on('finish', () => {
+    const end = process.hrtime.bigint();
+    const ms = Number(end - start) / 1e6;
+    const line = `${new Date().toISOString()},${req.originalUrl},${ms.toFixed(0)},${res.statusCode}\n`;
+    fs.appendFileSync(path.join(__dirname, '../../logs/sample_run.csv'), line);
+  });
+  next();
+});
+
 app.use(express.json());
 app.get('/health', (req, res) => res.send('healthy'));
 app.post('/api/content', (req, res) => res.json({ status: 'ok' }));


### PR DESCRIPTION
## Summary
- log each request in services to `logs/sample_run.csv`
- auto-install pandas and handle missing logs in `aggregate_metrics.py`
- run JMeter in CI and aggregate metrics
- drop JWT usage from JMeter and docs

## Testing
- `npm test` *(fails: jest not found)*
- `python3 scripts/aggregate_metrics.py` *(fails: could not install pandas due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684f4a3eb8dc8325ac1100b5e98eebcc