### PR TITLE
Add Kubernetes manifests and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ Install JMeter via `brew install jmeter` or download it from the [official archi
 jmeter -n -t jmeter/microservices-test-plan.jmx
 ```
 
+## Kubernetes Manifests
+Manifests for running the microservices on Kubernetes live in `k8s/`. They
+include Deployments, Services and an Ingress resource. Istio configuration
+under `k8s/istio/` enables mutual TLS between the services. Network policies
+restrict traffic so only the frontend or other backends can reach the
+microservices.
+
+To apply everything:
+```bash
+kubectl apply -f k8s/
+kubectl apply -f k8s/istio/
+```
+
 ## Logs
 Sample run data lives in `logs/sample_run.csv` for reference. Running
 `python metrics.py` generates `reports/metrics_report.pdf`.

--- a/k8s/account-svc.yaml
+++ b/k8s/account-svc.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: account-svc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: account-svc
+  template:
+    metadata:
+      labels:
+        app: account-svc
+        role: backend
+    spec:
+      containers:
+        - name: account-svc
+          image: account-svc:latest
+          ports:
+            - containerPort: 3000
+          env:
+            - name: CERT_DIR
+              value: /certs
+          volumeMounts:
+            - name: tls
+              mountPath: /certs
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+      volumes:
+        - name: tls
+          secret:
+            secretName: tls-secret
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: account-svc
+spec:
+  selector:
+    app: account-svc
+  ports:
+    - port: 80
+      targetPort: 3000

--- a/k8s/analytics-svc.yaml
+++ b/k8s/analytics-svc.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: analytics-svc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: analytics-svc
+  template:
+    metadata:
+      labels:
+        app: analytics-svc
+        role: backend
+    spec:
+      containers:
+        - name: analytics-svc
+          image: analytics-svc:latest
+          ports:
+            - containerPort: 3000
+          env:
+            - name: CERT_DIR
+              value: /certs
+            - name: REDIS_URL
+              value: redis://redis:6379
+          volumeMounts:
+            - name: tls
+              mountPath: /certs
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+      volumes:
+        - name: tls
+          secret:
+            secretName: tls-secret
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: analytics-svc
+spec:
+  selector:
+    app: analytics-svc
+  ports:
+    - port: 80
+      targetPort: 3000

--- a/k8s/content-svc.yaml
+++ b/k8s/content-svc.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: content-svc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: content-svc
+  template:
+    metadata:
+      labels:
+        app: content-svc
+        role: backend
+    spec:
+      containers:
+        - name: content-svc
+          image: content-svc:latest
+          ports:
+            - containerPort: 3000
+          env:
+            - name: CERT_DIR
+              value: /certs
+          volumeMounts:
+            - name: tls
+              mountPath: /certs
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+      volumes:
+        - name: tls
+          secret:
+            secretName: tls-secret
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: content-svc
+spec:
+  selector:
+    app: content-svc
+  ports:
+    - port: 80
+      targetPort: 3000

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: microservices
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /account
+            pathType: Prefix
+            backend:
+              service:
+                name: account-svc
+                port:
+                  number: 80
+          - path: /content
+            pathType: Prefix
+            backend:
+              service:
+                name: content-svc
+                port:
+                  number: 80
+          - path: /analytics
+            pathType: Prefix
+            backend:
+              service:
+                name: analytics-svc
+                port:
+                  number: 80

--- a/k8s/istio/destinationrules.yaml
+++ b/k8s/istio/destinationrules.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: account-mtls
+spec:
+  host: account-svc
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: content-mtls
+spec:
+  host: content-svc
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: analytics-mtls
+spec:
+  host: analytics-svc
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/k8s/istio/gateway.yaml
+++ b/k8s/istio/gateway.yaml
@@ -1,0 +1,49 @@
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: microservices-gw
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - "*"
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: microservices
+spec:
+  hosts:
+    - "*"
+  gateways:
+    - microservices-gw
+  http:
+    - match:
+        - uri:
+            prefix: /account
+      route:
+        - destination:
+            host: account-svc
+            port:
+              number: 80
+    - match:
+        - uri:
+            prefix: /content
+      route:
+        - destination:
+            host: content-svc
+            port:
+              number: 80
+    - match:
+        - uri:
+            prefix: /analytics
+      route:
+        - destination:
+            host: analytics-svc
+            port:
+              number: 80

--- a/k8s/istio/peerauth.yaml
+++ b/k8s/istio/peerauth.yaml
@@ -1,0 +1,7 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+spec:
+  mtls:
+    mode: STRICT

--- a/k8s/network-policy.yaml
+++ b/k8s/network-policy.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: backend-policy
+spec:
+  podSelector:
+    matchLabels:
+      role: backend
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              role: backend
+        - podSelector:
+            matchLabels:
+              app: frontend
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              role: backend
+  policyTypes:
+    - Ingress
+    - Egress

--- a/src/account-svc/Dockerfile
+++ b/src/account-svc/Dockerfile
@@ -3,4 +3,7 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 COPY server.js .
+# run as unprivileged user and rely on Node's OpenSSL build
+# to leverage AES-NI when available
+USER node
 CMD ["node","server.js"]

--- a/src/analytics-svc/Dockerfile
+++ b/src/analytics-svc/Dockerfile
@@ -3,4 +3,7 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 COPY server.js .
+# run as unprivileged user and rely on Node's OpenSSL build
+# to leverage AES-NI when available
+USER node
 CMD ["node","server.js"]

--- a/src/content-svc/Dockerfile
+++ b/src/content-svc/Dockerfile
@@ -3,4 +3,7 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 COPY server.js .
+# run as unprivileged user and rely on Node's OpenSSL build
+# to leverage AES-NI when available
+USER node
 CMD ["node","server.js"]

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Demo Frontend</title>
+</head>
+<body>
+  <h1>Microservices Demo</h1>
+  <button id="profile">Get Profile</button>
+  <pre id="profile-result"></pre>
+  <button id="post-content">Post Content</button>
+  <pre id="content-result"></pre>
+  <button id="analytics">Get Analytics</button>
+  <pre id="analytics-result"></pre>
+<script>
+const token = 'dummy';
+
+document.getElementById('profile').onclick = () => {
+  fetch('/account/api/profile', { headers: { 'Authorization': 'Bearer ' + token } })
+    .then(r => r.json())
+    .then(d => document.getElementById('profile-result').textContent = JSON.stringify(d, null, 2));
+};
+
+document.getElementById('post-content').onclick = () => {
+  fetch('/content/api/content', {
+    method: 'POST',
+    headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ data: 'demo' })
+  })
+    .then(r => r.json())
+    .then(d => document.getElementById('content-result').textContent = JSON.stringify(d, null, 2));
+};
+
+document.getElementById('analytics').onclick = () => {
+  fetch('/analytics/api/analytics', { headers: { 'Authorization': 'Bearer ' + token } })
+    .then(r => r.json())
+    .then(d => document.getElementById('analytics-result').textContent = JSON.stringify(d, null, 2));
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create Deployment/Service/Ingress manifests for each service
- add Istio configuration with strict mTLS
- include basic NetworkPolicy
- ensure Node containers run as non-root and document AES-NI
- add simple static frontend

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f591a5a0c8325829d125ca097dbb4