### PR TITLE
Handle analytics redis failures

### DIFF
--- a/src/analytics-svc/server.js
+++ b/src/analytics-svc/server.js
@@ -30,11 +30,22 @@ app.use((req, res, next) => {
 });
 app.use(express.json());
 
-const redis = createClient({ url: process.env.REDIS_URL || 'redis://redis:6379' });
+const redis = createClient({
+  url: process.env.REDIS_URL || 'redis://redis:6379',
+  disableOfflineQueue: true,
+  socket: { connectTimeout: 1000 },
+});
+redis.on('error', err => logger.error(err));
 redis.connect().catch(err => logger.error(err));
 
 app.use(async (req, res, next) => {
-  await redis.incr('analytics:requests');
+  try {
+    if (redis.isReady) {
+      await redis.incr('analytics:requests');
+    }
+  } catch (err) {
+    logger.error(err);
+  }
   next();
 });
 


### PR DESCRIPTION
## Summary
- protect analytics service from redis connection issues

## Testing
- `npm ci` *(fails: cannot access registry)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f62fc65688325b341647a6971b11e