### PR TITLE
Handle analytics test redis connection

### DIFF
--- a/src/analytics-svc/server.js
+++ b/src/analytics-svc/server.js
@@ -30,8 +30,16 @@ app.use((req, res, next) => {
 });
 app.use(express.json());
 
-const redis = createClient({ url: process.env.REDIS_URL || 'redis://redis:6379' });
-redis.connect().catch(err => logger.error(err));
+let redis;
+if (process.env.NODE_ENV === 'test') {
+  redis = {
+    incr: async () => {},
+    get: async () => null,
+  };
+} else {
+  redis = createClient({ url: process.env.REDIS_URL || 'redis://redis:6379' });
+  redis.connect().catch(err => logger.error(err));
+}
 
 app.use(async (req, res, next) => {
   await redis.incr('analytics:requests');


### PR DESCRIPTION
## Summary
- stub out redis client in analytics service when running tests

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f62fc65688325b341647a6971b11e