### PR TITLE
Fix analytics tests by stubbing Redis

### DIFF
--- a/src/analytics-svc/server.js
+++ b/src/analytics-svc/server.js
@@ -30,8 +30,20 @@ app.use((req, res, next) => {
 });
 app.use(express.json());
 
-const redis = createClient({ url: process.env.REDIS_URL || 'redis://redis:6379' });
-redis.connect().catch(err => logger.error(err));
+// Use a simple in-memory counter when running tests to avoid Redis dependency
+let redis;
+let requestCount = 0;
+if (process.env.NODE_ENV === 'test') {
+  redis = {
+    incr: async () => {
+      requestCount += 1;
+    },
+    get: async () => requestCount.toString(),
+  };
+} else {
+  redis = createClient({ url: process.env.REDIS_URL || 'redis://redis:6379' });
+  redis.connect().catch(err => logger.error(err));
+}
 
 app.use(async (req, res, next) => {
   await redis.incr('analytics:requests');


### PR DESCRIPTION
## Summary
- avoid Redis connection when `NODE_ENV=test` in `analytics-svc`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f62fc65688325b341647a6971b11e