### PR TITLE
Fix kind cluster setup in workflow

### DIFF
--- a/.github/workflows/local-perf-test.yaml
+++ b/.github/workflows/local-perf-test.yaml
@@ -60,13 +60,7 @@ jobs:
         uses: engineerd/setup-kind@v0.5.0
         with:
           version: v0.20.0
-          config: |
-            kind: Cluster
-            apiVersion: kind.x-k8s.io/v1alpha4
-            nodes:
-              - role: control-plane
-              - role: worker
-              - role: worker
+          config: kind-config.yaml
 
       - name: Install Istio (optional)
         if: runner.os != 'Windows'

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -1,0 +1,6 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker


### PR DESCRIPTION
## Summary
- move kind cluster config into dedicated file
- reference the config file in `local-perf-test.yaml`

## Testing
- `npm test` *(fails: jest not found because dependencies can't be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68508e7cd360832582e712b0a27a02f0