### PR TITLE
Fix kind setup on CI

### DIFF
--- a/.github/workflows/local-perf-test.yaml
+++ b/.github/workflows/local-perf-test.yaml
@@ -41,10 +41,7 @@ on:
 
 jobs:
   perf:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     env:
       THROUGHPUT_THRESHOLD: ${{ github.event.inputs.throughput_threshold || '0' }}
       LATENCY_THRESHOLD: ${{ github.event.inputs.latency_threshold || '1000000000' }}


### PR DESCRIPTION
## Summary
- run the local performance test workflow only on `ubuntu-latest`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685090e414148325bd8c0871b39070ae