### PR TITLE
Fix Istio path in workflow

### DIFF
--- a/.github/workflows/local-perf-test.yaml
+++ b/.github/workflows/local-perf-test.yaml
@@ -67,6 +67,7 @@ jobs:
             curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.20.1 sh -
             ISTIO_DIR=$(ls -d istio-*)
             echo "$ISTIO_DIR/bin" >> "$GITHUB_PATH"
+            export PATH="$PATH:$ISTIO_DIR/bin"
             istioctl install -y --set profile=minimal
           fi
 


### PR DESCRIPTION
## Summary
- ensure istioctl is available during workflow step

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850a66967488325aaf0c6ec39535bd8