### PR TITLE
Fix namespace setup in perf test workflow

### DIFF
--- a/.github/workflows/local-perf-test.yaml
+++ b/.github/workflows/local-perf-test.yaml
@@ -74,7 +74,12 @@ jobs:
       - name: Apply Kubernetes manifests
         shell: bash
         run: |
-          kubectl apply -f k8s/ --recursive
+          # Ensure namespace exists before applying other resources
+          kubectl apply -f k8s/namespace.yaml
+          # Apply all manifests except the deprecated PodSecurityPolicy
+          for f in $(find k8s -name '*.yaml' ! -name 'namespace.yaml' ! -name 'podsecuritypolicy.yaml' | sort); do
+            kubectl apply -f "$f"
+          done
           if [ -d "k8s/istio" ]; then
             kubectl apply -f k8s/istio/
           fi


### PR DESCRIPTION
## Summary
- ensure the microservices namespace exists before applying other k8s manifests
- skip deprecated PodSecurityPolicy manifest

## Testing
- `npm ci` *(fails: unable to connect to registry)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850b2ca6a9c8325934ec0775159640e