### PR TITLE
Fix wait for all pods command

### DIFF
--- a/.github/workflows/local-perf-test.yaml
+++ b/.github/workflows/local-perf-test.yaml
@@ -87,7 +87,8 @@ jobs:
       - name: Wait for all pods
         shell: bash
         run: |
-          kubectl wait --for=condition=available deployment --all -A --timeout=600s || true
+          # Wait only for deployments in the microservices namespace
+          kubectl wait --for=condition=available deployment --all -n microservices --timeout=600s || true
 
       - name: List all pods
         shell: bash

--- a/scripts/perf_helpers.sh
+++ b/scripts/perf_helpers.sh
@@ -13,7 +13,8 @@ prepare_results() {
 
 # Wait until all Kubernetes deployments are available
 wait_for_pods() {
-  kubectl wait --for=condition=available --timeout=300s deployment --all
+  local ns=${1:-microservices}
+  kubectl wait --for=condition=available --timeout=300s deployment --all -n "$ns"
 }
 
 # Flush Redis cache inside the cluster


### PR DESCRIPTION
## Summary
- tweak `kubectl wait` options in perf workflow
- make `wait_for_pods` accept namespace argument

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850b98c82348325bb8b2c50bbde956e