### PR TITLE
Build images locally in CI

### DIFF
--- a/.github/workflows/local-perf-test.yaml
+++ b/.github/workflows/local-perf-test.yaml
@@ -53,11 +53,28 @@ jobs:
         with:
           version: v1.28.0
 
+
       - name: Set up kind cluster with 3 nodes
         uses: engineerd/setup-kind@v0.5.0
         with:
           version: v0.20.0
           config: kind-config.yaml
+
+      - name: Build Docker images
+        shell: bash
+        run: |
+          set -e
+          for svc in account-svc analytics-svc auth-svc content-svc crypto-svc ids-agent; do
+            docker build -t "$svc:latest" "./src/$svc"
+          done
+
+      - name: Load images into kind
+        shell: bash
+        run: |
+          set -e
+          for svc in account-svc analytics-svc auth-svc content-svc crypto-svc ids-agent; do
+            kind load docker-image "$svc:latest"
+          done
 
       - name: Install Istio (optional)
         if: runner.os != 'Windows'

--- a/k8s/account-svc.yaml
+++ b/k8s/account-svc.yaml
@@ -18,7 +18,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: account-svc
-          image: ghcr.io/oleksiijko/account-svc:1.0
+          image: account-svc:latest
           ports:
             - containerPort: 3000
           env:

--- a/k8s/analytics-svc.yaml
+++ b/k8s/analytics-svc.yaml
@@ -18,7 +18,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: analytics-svc
-          image: ghcr.io/oleksiijko/analytics-svc:1.0
+          image: analytics-svc:latest
           ports:
             - containerPort: 3000
           env:

--- a/k8s/auth-svc.yaml
+++ b/k8s/auth-svc.yaml
@@ -18,7 +18,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: auth-svc
-          image: ghcr.io/oleksiijko/auth-svc:1.0
+          image: auth-svc:latest
           ports:
             - containerPort: 3000
           env:

--- a/k8s/content-svc.yaml
+++ b/k8s/content-svc.yaml
@@ -18,7 +18,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: content-svc
-          image: ghcr.io/oleksiijko/content-svc:1.0
+          image: content-svc:latest
           ports:
             - containerPort: 3000
           env:

--- a/k8s/crypto-svc.yaml
+++ b/k8s/crypto-svc.yaml
@@ -18,7 +18,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: crypto-svc
-          image: ghcr.io/oleksiijko/crypto-svc:1.0
+          image: crypto-svc:latest
           ports:
             - containerPort: 3000
           env:

--- a/k8s/ids-agent.yaml
+++ b/k8s/ids-agent.yaml
@@ -17,7 +17,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: ids-agent
-          image: ghcr.io/oleksiijko/ids-agent:1.0
+          image: ids-agent:latest
           env:
             - name: SIEM_URL
               value: http://siem.local/ingest


### PR DESCRIPTION
## Summary
- build Docker images for each microservice in CI
- load the built images into the kind cluster
- use the local `:latest` tags in Kubernetes manifests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850cffa81c88325a684f56eba0421ee