### PR TITLE
Fix Falco DaemonSet spec

### DIFF
--- a/k8s/observability/falco-daemonset.yaml
+++ b/k8s/observability/falco-daemonset.yaml
@@ -24,39 +24,39 @@ spec:
     metadata:
       labels:
         app: falco
-      spec:
-        hostPID: true
-        containers:
-        - name: falco
-          image: falcosecurity/falco:latest
-          securityContext:
-            privileged: true
-            runAsNonRoot: true
-            runAsUser: 1000
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
-            seccompProfile:
-              type: RuntimeDefault
-          volumeMounts:
-          - name: dev-fs
-            mountPath: /host/dev
-          - name: proc-fs
-            mountPath: /host/proc
-          - name: sys-fs
-            mountPath: /host/sys
-          - name: rules
-            mountPath: /etc/falco/rules.d
-        volumes:
+    spec:
+      hostPID: true
+      containers:
+      - name: falco
+        image: falcosecurity/falco:latest
+        securityContext:
+          privileged: true
+          runAsNonRoot: true
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
         - name: dev-fs
-          hostPath:
-            path: /dev
+          mountPath: /host/dev
         - name: proc-fs
-          hostPath:
-            path: /proc
+          mountPath: /host/proc
         - name: sys-fs
-          hostPath:
-            path: /sys
+          mountPath: /host/sys
         - name: rules
-          configMap:
-            name: falco-node-rules
+          mountPath: /etc/falco/rules.d
+      volumes:
+      - name: dev-fs
+        hostPath:
+          path: /dev
+      - name: proc-fs
+        hostPath:
+          path: /proc
+      - name: sys-fs
+        hostPath:
+          path: /sys
+      - name: rules
+        configMap:
+          name: falco-node-rules


### PR DESCRIPTION
## Summary
- fix `k8s/observability/falco-daemonset.yaml` so `spec.template.spec` has the proper structure

## Testing
- `kubectl apply -f k8s/observability/falco-daemonset.yaml --dry-run=client`

------
https://chatgpt.com/codex/tasks/task_e_68514db6d6b88325aac8120f25a7419e