### PR TITLE
Fix log directory for readonly rootfs

### DIFF
--- a/k8s/account-svc.yaml
+++ b/k8s/account-svc.yaml
@@ -25,6 +25,8 @@ spec:
           env:
             - name: CERT_DIR
               value: /certs
+            - name: LOG_DIR
+              value: /tmp
           resources:
             requests:
               cpu: "100m"

--- a/k8s/analytics-svc.yaml
+++ b/k8s/analytics-svc.yaml
@@ -27,6 +27,8 @@ spec:
               value: /certs
             - name: REDIS_URL
               value: redis://redis:6379
+            - name: LOG_DIR
+              value: /tmp
           resources:
             requests:
               cpu: "100m"

--- a/k8s/content-svc.yaml
+++ b/k8s/content-svc.yaml
@@ -25,6 +25,8 @@ spec:
           env:
             - name: CERT_DIR
               value: /certs
+            - name: LOG_DIR
+              value: /tmp
           resources:
             requests:
               cpu: "100m"

--- a/src/account-svc/server.js
+++ b/src/account-svc/server.js
@@ -6,7 +6,8 @@ const jwt = require('jsonwebtoken');
 const logger = require('winston');
 const app = express();
 
-const logFile = path.join(__dirname, '../../logs/sample_run.csv');
+const logDir = process.env.LOG_DIR || path.join(__dirname, '../../logs');
+const logFile = path.join(logDir, 'sample_run.csv');
 if (!fs.existsSync(logFile)) {
   fs.mkdirSync(path.dirname(logFile), { recursive: true });
   fs.writeFileSync(logFile, 'timestamp,url,rt_ms,http_code\n');

--- a/src/analytics-svc/server.js
+++ b/src/analytics-svc/server.js
@@ -7,7 +7,8 @@ const logger = require('winston');
 const Redis = require('ioredis');
 const app = express();
 
-const logFile = path.join(__dirname, '../../logs/sample_run.csv');
+const logDir = process.env.LOG_DIR || path.join(__dirname, '../../logs');
+const logFile = path.join(logDir, 'sample_run.csv');
 if (!fs.existsSync(logFile)) {
   fs.mkdirSync(path.dirname(logFile), { recursive: true });
   fs.writeFileSync(logFile, 'timestamp,url,rt_ms,http_code\n');

--- a/src/content-svc/server.js
+++ b/src/content-svc/server.js
@@ -6,7 +6,8 @@ const jwt = require('jsonwebtoken');
 const logger = require('winston');
 const app = express();
 
-const logFile = path.join(__dirname, '../../logs/sample_run.csv');
+const logDir = process.env.LOG_DIR || path.join(__dirname, '../../logs');
+const logFile = path.join(logDir, 'sample_run.csv');
 if (!fs.existsSync(logFile)) {
   fs.mkdirSync(path.dirname(logFile), { recursive: true });
   fs.writeFileSync(logFile, 'timestamp,url,rt_ms,http_code\n');


### PR DESCRIPTION
## Summary
- allow setting `LOG_DIR` for account-svc, analytics-svc and content-svc
- default to `/tmp` in Kubernetes manifests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685161e441008325bbde8ee23b330ff1