### PR TITLE
Fix microservice containers logging path

### DIFF
--- a/src/account-svc/Dockerfile
+++ b/src/account-svc/Dockerfile
@@ -1,7 +1,9 @@
 FROM node:18-alpine
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev && \
+    mkdir -p /logs && \
+    chown node:node /logs
 COPY server.js .
 # run as unprivileged user and rely on Node's OpenSSL build
 # to leverage AES-NI when available

--- a/src/analytics-svc/Dockerfile
+++ b/src/analytics-svc/Dockerfile
@@ -1,7 +1,9 @@
 FROM node:18-alpine
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev && \
+    mkdir -p /logs && \
+    chown node:node /logs
 COPY server.js .
 # run as unprivileged user and rely on Node's OpenSSL build
 # to leverage AES-NI when available

--- a/src/content-svc/Dockerfile
+++ b/src/content-svc/Dockerfile
@@ -1,7 +1,9 @@
 FROM node:18-alpine
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev && \
+    mkdir -p /logs && \
+    chown node:node /logs
 COPY server.js .
 # run as unprivileged user and rely on Node's OpenSSL build
 # to leverage AES-NI when available


### PR DESCRIPTION
## Summary
- ensure `/logs` directory exists in Dockerfiles for account, analytics, and content services

## Testing
- `npm ci`
- `for svc in account-svc analytics-svc content-svc auth-svc crypto-svc ids-agent; do (cd src/$svc && npm ci >/dev/null); done`
- `cd src/api-gateway && npm ci >/dev/null && cd ../..`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685161e441008325bbde8ee23b330ff1