### PR TITLE
Add network policies and deploy script

### DIFF
--- a/k8s/network-policy-dns-egress.yaml
+++ b/k8s/network-policy-dns-egress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: microservices
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53

--- a/k8s/network-policy-internal.yaml
+++ b/k8s/network-policy-internal.yaml
@@ -1,10 +1,16 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: default-deny-all
+  name: allow-internal-traffic
   namespace: microservices
 spec:
   podSelector: {}
   policyTypes:
   - Ingress
   - Egress
+  ingress:
+  - from:
+    - podSelector: {}
+  egress:
+  - to:
+    - podSelector: {}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+kubectl apply -f k8s/ -n microservices
+
+deployments=$(kubectl get deployments -n microservices -o jsonpath='{.items[*].metadata.name}')
+for d in $deployments; do
+  if ! kubectl rollout status deployment/$d -n microservices --timeout=60s; then
+    kubectl describe pods -n microservices
+    kubectl logs -n microservices --all-containers --tail=50
+    exit 1
+  fi
+done


### PR DESCRIPTION
## Summary
- add network policy to allow DNS egress
- allow all traffic within microservices namespace
- deny all other traffic
- add deploy script with rollout checks

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516f5832b48325ad1c490e288d0ce1