### PR TITLE
Configure writable log paths

### DIFF
--- a/k8s/account-svc.yaml
+++ b/k8s/account-svc.yaml
@@ -26,7 +26,7 @@ spec:
             - name: CERT_DIR
               value: /certs
             - name: LOG_DIR
-              value: /tmp
+              value: /app/logs
           resources:
             requests:
               cpu: "100m"
@@ -39,6 +39,8 @@ spec:
               mountPath: /certs
             - name: tmp-storage
               mountPath: /tmp
+            - name: logs
+              mountPath: /app/logs
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -53,6 +55,8 @@ spec:
           secret:
             secretName: tls-secret
         - name: tmp-storage
+          emptyDir: {}
+        - name: logs
           emptyDir: {}
 ---
 apiVersion: v1

--- a/k8s/analytics-svc.yaml
+++ b/k8s/analytics-svc.yaml
@@ -28,7 +28,7 @@ spec:
             - name: REDIS_URL
               value: redis://redis:6379
             - name: LOG_DIR
-              value: /tmp
+              value: /app/logs
           resources:
             requests:
               cpu: "100m"
@@ -39,6 +39,8 @@ spec:
           volumeMounts:
             - name: tls
               mountPath: /certs
+            - name: logs
+              mountPath: /app/logs
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -52,6 +54,8 @@ spec:
         - name: tls
           secret:
             secretName: tls-secret
+        - name: logs
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/auth-svc.yaml
+++ b/k8s/auth-svc.yaml
@@ -40,6 +40,8 @@ spec:
           volumeMounts:
             - name: tls
               mountPath: /certs
+            - name: logs
+              mountPath: /app/logs
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -53,6 +55,8 @@ spec:
         - name: tls
           secret:
             secretName: tls-secret
+        - name: logs
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/content-svc.yaml
+++ b/k8s/content-svc.yaml
@@ -26,7 +26,7 @@ spec:
             - name: CERT_DIR
               value: /certs
             - name: LOG_DIR
-              value: /tmp
+              value: /app/logs
           resources:
             requests:
               cpu: "100m"
@@ -37,6 +37,8 @@ spec:
           volumeMounts:
             - name: tls
               mountPath: /certs
+            - name: logs
+              mountPath: /app/logs
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -50,6 +52,8 @@ spec:
         - name: tls
           secret:
             secretName: tls-secret
+        - name: logs
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/crypto-svc.yaml
+++ b/k8s/crypto-svc.yaml
@@ -40,6 +40,8 @@ spec:
           volumeMounts:
             - name: tls
               mountPath: /certs
+            - name: logs
+              mountPath: /app/logs
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -53,6 +55,8 @@ spec:
         - name: tls
           secret:
             secretName: tls-secret
+        - name: logs
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/ids-agent.yaml
+++ b/k8s/ids-agent.yaml
@@ -22,6 +22,9 @@ spec:
           env:
             - name: SIEM_URL
               value: http://siem.local/ingest
+          volumeMounts:
+            - name: logs
+              mountPath: /app/logs
           resources:
             requests:
               cpu: "50m"
@@ -38,6 +41,9 @@ spec:
               drop: ["ALL"]
             seccompProfile:
               type: RuntimeDefault
+      volumes:
+        - name: logs
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/src/account-svc/Dockerfile
+++ b/src/account-svc/Dockerfile
@@ -2,8 +2,9 @@ FROM node:18-alpine
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev && \
-    mkdir -p /logs && \
-    chown node:node /logs
+    mkdir -p /app/logs && \
+    chown node:node /app/logs
+ENV LOG_DIR=/app/logs
 COPY server.js .
 # run as unprivileged user and rely on Node's OpenSSL build
 # to leverage AES-NI when available

--- a/src/account-svc/server.js
+++ b/src/account-svc/server.js
@@ -6,7 +6,7 @@ const jwt = require('jsonwebtoken');
 const logger = require('winston');
 const app = express();
 
-const logDir = process.env.LOG_DIR || path.join(__dirname, '../../logs');
+const logDir = process.env.LOG_DIR || '/app/logs';
 const logFile = path.join(logDir, 'sample_run.csv');
 if (!fs.existsSync(logFile)) {
   fs.mkdirSync(path.dirname(logFile), { recursive: true });

--- a/src/analytics-svc/Dockerfile
+++ b/src/analytics-svc/Dockerfile
@@ -2,8 +2,9 @@ FROM node:18-alpine
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev && \
-    mkdir -p /logs && \
-    chown node:node /logs
+    mkdir -p /app/logs && \
+    chown node:node /app/logs
+ENV LOG_DIR=/app/logs
 COPY server.js .
 # run as unprivileged user and rely on Node's OpenSSL build
 # to leverage AES-NI when available

--- a/src/analytics-svc/server.js
+++ b/src/analytics-svc/server.js
@@ -7,7 +7,7 @@ const logger = require('winston');
 const Redis = require('ioredis');
 const app = express();
 
-const logDir = process.env.LOG_DIR || path.join(__dirname, '../../logs');
+const logDir = process.env.LOG_DIR || '/app/logs';
 const logFile = path.join(logDir, 'sample_run.csv');
 if (!fs.existsSync(logFile)) {
   fs.mkdirSync(path.dirname(logFile), { recursive: true });

--- a/src/auth-svc/Dockerfile
+++ b/src/auth-svc/Dockerfile
@@ -1,6 +1,10 @@
 FROM node:18-alpine
 WORKDIR /app
 COPY package.json package-lock.json* ./
-RUN npm install --production
+RUN npm install --production && \
+    mkdir -p /app/logs && \
+    chown node:node /app/logs
+ENV LOG_DIR=/app/logs
 COPY . .
+USER node
 CMD ["node", "server.js"]

--- a/src/content-svc/Dockerfile
+++ b/src/content-svc/Dockerfile
@@ -2,8 +2,9 @@ FROM node:18-alpine
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev && \
-    mkdir -p /logs && \
-    chown node:node /logs
+    mkdir -p /app/logs && \
+    chown node:node /app/logs
+ENV LOG_DIR=/app/logs
 COPY server.js .
 # run as unprivileged user and rely on Node's OpenSSL build
 # to leverage AES-NI when available

--- a/src/content-svc/server.js
+++ b/src/content-svc/server.js
@@ -6,7 +6,7 @@ const jwt = require('jsonwebtoken');
 const logger = require('winston');
 const app = express();
 
-const logDir = process.env.LOG_DIR || path.join(__dirname, '../../logs');
+const logDir = process.env.LOG_DIR || '/app/logs';
 const logFile = path.join(logDir, 'sample_run.csv');
 if (!fs.existsSync(logFile)) {
   fs.mkdirSync(path.dirname(logFile), { recursive: true });

--- a/src/crypto-svc/Dockerfile
+++ b/src/crypto-svc/Dockerfile
@@ -1,7 +1,10 @@
 FROM node:18-alpine
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev && \
+    mkdir -p /app/logs && \
+    chown node:node /app/logs
+ENV LOG_DIR=/app/logs
 COPY server.js policy.json ./
 USER node
 CMD ["node","server.js"]

--- a/src/ids-agent/Dockerfile
+++ b/src/ids-agent/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.9-slim
 WORKDIR /app
 COPY agent.py requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt && \
+    mkdir -p /app/logs && \
+    chown nobody:nogroup /app/logs
+ENV LOG_DIR=/app/logs
+USER nobody
 CMD ["python", "agent.py"]


### PR DESCRIPTION
## Summary
- use `/app/logs` as default LOG_DIR in Node services
- ensure containers create and own `/app/logs`
- mount ephemeral log volumes in Kubernetes manifests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68517993285c83258fe8651fb032aefe