### PR TITLE
Add TLS certs to account service image

### DIFF
--- a/src/account-svc/Dockerfile
+++ b/src/account-svc/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:18-alpine
 WORKDIR /app
 COPY package.json package-lock.json ./
+COPY cert.pem key.pem ./
 RUN npm ci --omit=dev && \
     mkdir -p /app/logs && \
     chown node:node /app/logs


### PR DESCRIPTION
## Summary
- copy `cert.pem` and `key.pem` into the account service Docker build

## Testing
- `npm ci`
- `npm ci --prefix src/account-svc`
- `npm install --prefix src/account-svc`
- `npm ci --prefix src/content-svc`
- `npm install --prefix src/content-svc`
- `npm ci --prefix src/analytics-svc`
- `npm install --prefix src/analytics-svc`
- `npm ci --prefix src/crypto-svc`
- `npm install --prefix src/crypto-svc`
- `npm ci --prefix src/api-gateway`
- `npm install --prefix src/api-gateway`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68517c5626d48325bb52cdf081842a4b