### PR TITLE
Fix cert mount paths

### DIFF
--- a/k8s/account-svc.yaml
+++ b/k8s/account-svc.yaml
@@ -54,6 +54,13 @@ spec:
         - name: tls
           secret:
             secretName: tls-secret
+              items:
+                - key: tls.crt
+                  path: server.crt
+                - key: tls.crt
+                  path: ca.crt
+                - key: tls.key
+                  path: server.key
         - name: tmp-storage
           emptyDir: {}
         - name: logs

--- a/k8s/analytics-svc.yaml
+++ b/k8s/analytics-svc.yaml
@@ -54,6 +54,13 @@ spec:
         - name: tls
           secret:
             secretName: tls-secret
+              items:
+                - key: tls.crt
+                  path: server.crt
+                - key: tls.crt
+                  path: ca.crt
+                - key: tls.key
+                  path: server.key
         - name: logs
           emptyDir: {}
 ---

--- a/k8s/auth-svc.yaml
+++ b/k8s/auth-svc.yaml
@@ -55,6 +55,13 @@ spec:
         - name: tls
           secret:
             secretName: tls-secret
+              items:
+                - key: tls.crt
+                  path: server.crt
+                - key: tls.crt
+                  path: ca.crt
+                - key: tls.key
+                  path: server.key
         - name: logs
           emptyDir: {}
 ---

--- a/k8s/content-svc.yaml
+++ b/k8s/content-svc.yaml
@@ -52,6 +52,13 @@ spec:
         - name: tls
           secret:
             secretName: tls-secret
+              items:
+                - key: tls.crt
+                  path: server.crt
+                - key: tls.crt
+                  path: ca.crt
+                - key: tls.key
+                  path: server.key
         - name: logs
           emptyDir: {}
 ---

--- a/k8s/crypto-svc.yaml
+++ b/k8s/crypto-svc.yaml
@@ -55,6 +55,13 @@ spec:
         - name: tls
           secret:
             secretName: tls-secret
+              items:
+                - key: tls.crt
+                  path: server.crt
+                - key: tls.crt
+                  path: ca.crt
+                - key: tls.key
+                  path: server.key
         - name: logs
           emptyDir: {}
 ---


### PR DESCRIPTION
## Summary
- map tls secret keys to files that Node services expect

## Testing
- `npm install`
- `for d in src/*-svc src/api-gateway; do npm install --prefix "$d" >/dev/null; done`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68518eba45488325a52b0231f281f462